### PR TITLE
feat: Implement user-configurable media path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# configuration files
+backend/config.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 我需要在手机上或者电脑浏览器上管理本机电脑媒体路径里的所有图片和视频（递归遍历图片和视频类型）
-电脑媒体路径：/Users/bu/Desktop/img
+电脑媒体路径：用户首次启动时通过设置界面自行配置。
 
 技术：
 Python  fastapi sqlite
@@ -9,9 +9,30 @@ Python  fastapi sqlite
 ![image](https://github.com/user-attachments/assets/5f108c31-bc6c-44ba-843d-0319e9f00852)
 ![image](https://github.com/user-attachments/assets/cb26e167-db9e-483b-a660-b354c3c9643d)
 
+## 快速开始
 
+1.  **启动后端服务**:
+    *   后端服务由 Python FastAPI 构建。
+    *   请先确保您已安装 `requirements.txt` 中列出的依赖 (例如 `pip install -r requirements.txt`)。
+    *   进入项目根目录，运行 `python run.py` 来启动后端服务。
+    *   或者，您可以使用提供的脚本 `start.sh` (适用于 Linux/macOS) 或 `start.bat` (适用于 Windows)。
+    *   后端服务默认运行在 `http://localhost:8000`。
 
+2.  **启动前端应用**:
+    *   前端应用由 Next.js 构建。
+    *   在项目根目录，首先运行 `pnpm install` 以安装所有前端依赖。
+    *   然后运行 `pnpm dev` 来启动前端开发服务器。
+    *   应用通常会在浏览器中的 `http://localhost:3000` 打开。
 
+3.  **设置媒体路径**:
+    *   当您首次在开发模式下（即后端服务已连接）启动前端应用时，会看到一个设置表单。
+    *   在此表单中，请输入您电脑上存放图片和视频的媒体目录的**绝对路径**。
+        *   例如 (macOS/Linux): `/Users/yourname/Pictures/MyMediaCollection`
+        *   例如 (Windows): `C:\Users\yourname\My Videos`
+    *   提交路径后，应用会自动扫描该目录下的媒体文件。扫描完成后，您就可以开始浏览您的媒体库了。
+    *   此路径会保存在后端的一个配置文件中 (`backend/config.json`)，后续启动将自动加载此路径并提供服务。
+
+## 功能列表
 
 1、
 主页
@@ -36,4 +57,3 @@ sequenceDiagram
     Server-->>Client: { seed: "a1b2c3" }
     Client->>Server: GET /adjacent?id=id3&dir=next (切换图片)
     Server-->>Client: { next_id: "id1" }
-

--- a/backend/config_manager.py
+++ b/backend/config_manager.py
@@ -1,0 +1,24 @@
+import json
+import os
+
+CONFIG_FILE = os.path.join(os.path.dirname(__file__), "config.json")
+
+def save_media_path(path: str):
+    """Saves the given media path to config.json."""
+    with open(CONFIG_FILE, "w") as f:
+        json.dump({"media_path": path}, f)
+
+def load_media_path() -> str | None:
+    """Loads the media path from config.json.
+
+    Returns:
+        The path if found, else None.
+    """
+    if os.path.exists(CONFIG_FILE):
+        with open(CONFIG_FILE, "r") as f:
+            try:
+                data = json.load(f)
+                return data.get("media_path")
+            except json.JSONDecodeError:
+                return None
+    return None

--- a/backend/media_scanner.py
+++ b/backend/media_scanner.py
@@ -82,15 +82,12 @@ def scan_media_directory(root_path: str, db: Session) -> Dict[str, Any]:
             
             if is_media_file(file_path):
                 try:
-                    # Convert backslashes to forward slashes for web paths
-                    # 使用 urllib.parse.quote 来处理中文和特殊字符
-                    rel_path = os.path.relpath(file_path, '.')
-                    web_path = "/" + rel_path.replace('\\', '/')
+                    # Calculate path relative to the root_path
+                    rel_path = os.path.relpath(file_path, root_path)
+                    # Ensure forward slashes for web compatibility
+                    web_path = rel_path.replace('\\', '/')
                     
-                    # 检查文件是否已存在于数据库中
-                    db_media = db.query(models.Media).filter(models.Media.path == web_path).first  '/')
-                    
-                    # 检查文件是否已存在于数据库中
+                    # Check if the media item already exists in the database
                     db_media = db.query(models.Media).filter(models.Media.path == web_path).first()
                     
                     if not db_media:


### PR DESCRIPTION
This feature allows you to define your own media directory path through a setup form on the first launch, providing an out-of-the-box experience.

Key changes include:

- Backend:
  - Added `config_manager.py` to store and load the media path from `backend/config.json`.
  - Modified `main.py` to load the path on startup, dynamically mount it for static file serving under `/user_media_files`, and provide an API endpoint (`/api/config/media_path`) to manage/view the path.
  - The `/api/scan` endpoint now saves the provided path to the configuration.
  - Updated `media_scanner.py` to save media paths relative to the configured root directory.
- Frontend:
  - Updated `lib/api.ts` (`getMediaUrl`) to construct media URLs using the new `/user_media_files` base.
  - Modified `app/page.tsx` to check for backend media path configuration on load. If not configured (in dev mode), it directs you to `SetupForm`.
  - `SetupForm` allows you to input the absolute path to your media.
- Documentation:
  - Updated `README.md` with new setup instructions and removed references to a hardcoded media path.

This resolves the issue of needing a pre-configured path and makes the application more user-friendly and adaptable to different environments.